### PR TITLE
Refactoring AWS Authentication across the plugins

### DIFF
--- a/fetch/src/main/java/com/indix/gocd/s3fetch/FetchExecutor.java
+++ b/fetch/src/main/java/com/indix/gocd/s3fetch/FetchExecutor.java
@@ -1,5 +1,6 @@
 package com.indix.gocd.s3fetch;
 
+import com.amazonaws.auth.AWSCredentialsProviderChain;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.auth.InstanceProfileCredentialsProvider;
 import com.amazonaws.services.s3.AmazonS3Client;
@@ -57,17 +58,7 @@ public class FetchExecutor implements TaskExecutor {
     }
 
     public S3ArtifactStore s3ArtifactStore(FetchConfig config) {
-        return new S3ArtifactStore(s3Client(config), config.getS3Bucket());
-    }
-
-    public AmazonS3Client s3Client(FetchConfig config) {
-        AmazonS3Client client = null;
-        if (config.hasAWSUseIamRole()) {
-            client = new AmazonS3Client(new InstanceProfileCredentialsProvider());
-        } else {
-            client = new AmazonS3Client(new BasicAWSCredentials(config.getAWSAccessKeyId(), config.getAWSSecretAccessKey()));
-        }
-        return client;
+        return S3ArtifactStore.createStore(config.getAWSAccessKeyId(), config.getAWSSecretAccessKey(), config.getS3Bucket());
     }
 
     public FetchConfig getFetchConfig(TaskConfig config, TaskExecutionContext context) {

--- a/fetch/src/test/java/com/indix/gocd/s3fetch/FetchExecutorTest.java
+++ b/fetch/src/test/java/com/indix/gocd/s3fetch/FetchExecutorTest.java
@@ -66,10 +66,9 @@ public class FetchExecutorTest {
     @Test
     public void shouldBeFailureIfUnableToFetchArtifacts() {
         Map<String, String> mockVariables = mockEnvironmentVariables.build();
-        AmazonS3Client mockClient = mockClient();
-        doReturn(mockClient).when(fetchExecutor).s3Client(any(FetchConfig.class));
-        doThrow(new AmazonClientException("Exception message")).when(mockClient).listObjects(any(ListObjectsRequest.class));
-
+        S3ArtifactStore mockStore = mockStore();
+        doThrow(new AmazonClientException("Exception message")).when(mockStore).getPrefix(anyString(), anyString());
+        doReturn(mockStore).when(fetchExecutor).s3ArtifactStore(any(FetchConfig.class));
         ExecutionResult executionResult = fetchExecutor.execute(config, mockContext(mockVariables));
 
         assertFalse(executionResult.isSuccessful());

--- a/material/src/main/java/com/indix/gocd/s3material/plugin/S3PackageMaterialPoller.java
+++ b/material/src/main/java/com/indix/gocd/s3material/plugin/S3PackageMaterialPoller.java
@@ -19,7 +19,7 @@ public class S3PackageMaterialPoller implements PackageMaterialPoller {
     public PackageRevision getLatestRevision(PackageConfiguration packageConfiguration, RepositoryConfiguration repositoryConfiguration) {
         String s3Bucket = repositoryConfiguration.get(S3PackageMaterialConfiguration.S3_BUCKET).getValue();
         S3ArtifactStore artifactStore = s3ArtifactStore(s3Bucket);
-        RevisionStatus revision = artifactStore.getLatest(s3Client(), artifact(packageConfiguration));
+        RevisionStatus revision = artifactStore.getLatest(artifact(packageConfiguration));
         return new PackageRevision(revision.revision.getRevision(), revision.lastModified, revision.user,
                     String.format("Original revision number: %s",
                     StringUtils.isNullOrEmpty(revision.revisionLabel) ? "unavailable" : revision.revisionLabel),
@@ -61,18 +61,8 @@ public class S3PackageMaterialPoller implements PackageMaterialPoller {
             return ExecutionResult.failure(String.format("Couldn't find artifact at [%s]", prefix));
     }
 
-    private static AmazonS3Client s3Client() {
-        // The s3 client has a nice way to pick up the creds.
-        // It first checks the env to see if it contains the required key related variables/values
-        // If not, it checks the java system properties to see if it's set there(ideally via -D args)
-        // If not, it falls back to check ~/.aws/credentials file
-        // If not, finally, very insecure way, it tries to fetch from the internal metadata service that each
-        // instance comes with(if its exposed).
-        return new AmazonS3Client();
-    }
-
     public S3ArtifactStore s3ArtifactStore(String s3Bucket) {
-        return new S3ArtifactStore(s3Client(), s3Bucket);
+        return S3ArtifactStore.createStore("", "", s3Bucket);
     }
 
     private Artifact artifact(PackageConfiguration packageConfig) {

--- a/material/src/test/scala/material/plugin/config/S3PackageMaterialPollerSpec.scala
+++ b/material/src/test/scala/material/plugin/config/S3PackageMaterialPollerSpec.scala
@@ -52,7 +52,7 @@ class S3PackageMaterialPollerSpec extends WordSpec with MockitoSugar  {
     "getting latest revision" should {
       "include original revision label if it exists" in {
 
-        when(mockS3ArtifactStore.getLatest(Matchers.any[AmazonS3Client], Matchers.any[Artifact])).thenReturn(
+        when(mockS3ArtifactStore.getLatest(Matchers.any[Artifact])).thenReturn(
           new RevisionStatus(new Revision("2.1"),new Date(), "url", "user", "3.1")
         );
 
@@ -63,7 +63,7 @@ class S3PackageMaterialPollerSpec extends WordSpec with MockitoSugar  {
 
       "say the original revision label is unavailable if it doesn't exist" in {
 
-        when(mockS3ArtifactStore.getLatest(Matchers.any[AmazonS3Client], Matchers.any[Artifact])).thenReturn(
+        when(mockS3ArtifactStore.getLatest(Matchers.any[Artifact])).thenReturn(
           new RevisionStatus(new Revision("2.1"),new Date(), "url", "user")
         );
 

--- a/utils/src/main/java/com/indix/gocd/utils/creds/AnonAWSCredentialsProvider.java
+++ b/utils/src/main/java/com/indix/gocd/utils/creds/AnonAWSCredentialsProvider.java
@@ -1,0 +1,21 @@
+package com.indix.gocd.utils.creds;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AnonymousAWSCredentials;
+
+public class AnonAWSCredentialsProvider implements AWSCredentialsProvider {
+    @Override
+    public AWSCredentials getCredentials() {
+        return new AnonymousAWSCredentials();
+    }
+
+    @Override
+    public void refresh() {
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName();
+    }
+}

--- a/utils/src/main/java/com/indix/gocd/utils/creds/BasicAWSCredentialsProvider.java
+++ b/utils/src/main/java/com/indix/gocd/utils/creds/BasicAWSCredentialsProvider.java
@@ -1,0 +1,34 @@
+package com.indix.gocd.utils.creds;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+
+public class BasicAWSCredentialsProvider implements AWSCredentialsProvider {
+    private String accessKey;
+    private String secretKey;
+
+    public BasicAWSCredentialsProvider(String accessKey, String secretKey) {
+        this.accessKey = accessKey;
+        this.secretKey = secretKey;
+    }
+
+    public AWSCredentials getCredentials() {
+        if (accessKey != null && secretKey != null) {
+            return new BasicAWSCredentials(accessKey, secretKey);
+        }
+
+        throw new AmazonClientException(
+                "Access key or secret key is null");
+    }
+
+    public void refresh() {
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName();
+    }
+
+}


### PR DESCRIPTION
Not using special environment variables like AWS_USE_IAM_ROLE to enable the IAM Role Access. Using the AWS SDK's AWSCredentialsProviderChain in the following order
- Environment Variable Based
- System Properties Based
- Profile on the credentials file based
- Instance Profile based
- Basic Auth using the Keys from the configuration property explicitly
- Anonymous access (if enabled)

@manojlds @brewkode Feedback please. 
