### PR TITLE
Handle corner case in getLatest artifact, which cascades to Poller

### DIFF
--- a/material/src/main/java/com/indix/gocd/s3material/plugin/S3PackageMaterialPoller.java
+++ b/material/src/main/java/com/indix/gocd/s3material/plugin/S3PackageMaterialPoller.java
@@ -76,6 +76,11 @@ public class S3PackageMaterialPoller implements GoPlugin {
         S3ArtifactStore artifactStore = s3ArtifactStore(s3Bucket);
         try {
             RevisionStatus revision = artifactStore.getLatest(artifact(packageKeyValuePairs));
+            if (!revision.isValid) {
+                logger.warn("Received invalid revision from artifact store with this message: "+revision.toString());
+                return createResponse(DefaultGoPluginApiResponse.INTERNAL_ERROR, revision.toMap());
+            }
+
             if(new Revision(revision.revision.getRevision()).compareTo(new Revision(previousRevision)) > 0) {
                 return createResponse(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE, revision.toMap());
             }

--- a/publish/src/main/java/com/indix/gocd/s3publish/PublishExecutor.java
+++ b/publish/src/main/java/com/indix/gocd/s3publish/PublishExecutor.java
@@ -55,6 +55,8 @@ public class PublishExecutor {
                 }
             }
 
+            // A configured destination prefix is used to deploy files rather than publish artifacts
+            // We want to set metadata only when publishing artifacts
             if(!hasConfigDestinationPrefix(config)) {
                 setMetadata(env, bucket, destinationPrefix, store);
             }

--- a/utils/src/main/java/com/indix/gocd/models/BadRevisionStatus.java
+++ b/utils/src/main/java/com/indix/gocd/models/BadRevisionStatus.java
@@ -1,0 +1,33 @@
+package com.indix.gocd.models;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class BadRevisionStatus extends RevisionStatus {
+    public Artifact artifact = null;
+    public Boolean isValid = false;
+    public String msg = null;
+    public BadRevisionStatus(Artifact artifact, String msg) {
+        super(artifact.revision, null, null, null, null);
+        this.artifact = artifact;
+        this.msg = msg;
+        this.isValid = false;
+    }
+
+    @Override
+    public String toString() {
+        return "BadRevisionStatus{" +
+                "artifact=" + artifact.prefixWithRevision() +
+                ", msg=" + msg +
+                '}';
+    }
+
+    @Override
+    public Map toMap() {
+        final HashMap result = new HashMap();
+        result.put("artifact", artifact.prefixWithRevision());
+        result.put("msg", this.msg);
+
+        return result;
+    }
+}

--- a/utils/src/main/java/com/indix/gocd/models/Revision.java
+++ b/utils/src/main/java/com/indix/gocd/models/Revision.java
@@ -1,5 +1,7 @@
 package com.indix.gocd.models;
 
+import java.util.Arrays;
+
 public class Revision implements Comparable {
     private String revision;
     private String[] parts;

--- a/utils/src/main/java/com/indix/gocd/models/RevisionStatus.java
+++ b/utils/src/main/java/com/indix/gocd/models/RevisionStatus.java
@@ -13,6 +13,7 @@ public class RevisionStatus {
     public String tracebackUrl;
     public String user;
     public String revisionLabel;
+    public Boolean isValid = true;
     private static final String DATE_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
 
     public RevisionStatus(Revision revision, Date lastModified, String tracebackUrl, String user) {

--- a/utils/src/main/java/com/indix/gocd/utils/store/S3ArtifactStore.java
+++ b/utils/src/main/java/com/indix/gocd/utils/store/S3ArtifactStore.java
@@ -7,10 +7,7 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.*;
-import com.indix.gocd.models.Artifact;
-import com.indix.gocd.models.ResponseMetadataConstants;
-import com.indix.gocd.models.Revision;
-import com.indix.gocd.models.RevisionStatus;
+import com.indix.gocd.models.*;
 import com.indix.gocd.utils.GoEnvironment;
 import com.indix.gocd.utils.utils.Function;
 import com.indix.gocd.utils.utils.Functions;
@@ -183,6 +180,9 @@ public class S3ArtifactStore {
         ObjectListing listing = client.listObjects(listObjectsRequest);
         if (listing != null) {
             Revision recent = latestOf(listing);
+            if (recent.compareTo(Revision.base()) == 0) {
+                return new BadRevisionStatus(artifact, "No artifacts found which are later than this");
+            }
             Artifact artifactWithRevision = artifact.withRevision(recent);
             GetObjectMetadataRequest objectMetadataRequest = new GetObjectMetadataRequest(bucket, artifactWithRevision.prefixWithRevision());
             ObjectMetadata metadata = client.getObjectMetadata(objectMetadataRequest);

--- a/utils/src/test/java/com/indix/gocd/utils/store/S3ArtifactStoreTest.java
+++ b/utils/src/test/java/com/indix/gocd/utils/store/S3ArtifactStoreTest.java
@@ -4,6 +4,9 @@ import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.ListObjectsRequest;
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.indix.gocd.models.Artifact;
+import com.indix.gocd.models.BadRevisionStatus;
+import com.indix.gocd.models.RevisionStatus;
 import com.indix.gocd.utils.GoEnvironment;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -20,6 +23,7 @@ import static com.indix.gocd.utils.Constants.AWS_SECRET_ACCESS_KEY;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.*;
 
@@ -113,6 +117,18 @@ public class S3ArtifactStoreTest {
         String prefix = store.getLatestPrefix("pipeline", "stage", "job", "1");
         assertNull(prefix);
     }
+
+    @Test
+    public void shouldReturnBadRevisionStatusOnGetLatest() {
+        ObjectListing listing = new ObjectListing();
+        doReturn(listing).when(mockClient).listObjects(any(ListObjectsRequest.class));
+        S3ArtifactStore store = new S3ArtifactStore(mockClient, "foo-bar");
+
+        RevisionStatus status = store.getLatest(new Artifact("pipeline", "stage", "job"));
+        assertNotNull(status);
+        assertEquals(status instanceof BadRevisionStatus, true);
+    }
+
 
     @Test
     public void shouldReturnTheLatestStageCounter() {


### PR DESCRIPTION
In our setup, we've noticed that `getObjectMetadata` request (after doing a getLatest) fails with 404. One possible code path that leads to this is `getLatest` returning `Revisions.base()`, which is problematic, since, we consider it to be a valid revision and try to do a metadata fetch. Added a fix to handle it with some logging enabled on the plug-in side.

