### PR TITLE
Fix for newer versions of GoCD

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,9 @@ val commonsIo = "commons-io" % "commons-io" % "1.3.2"
 val awsS3 = "com.amazonaws" % "aws-java-sdk-s3" % "1.11.127"
 val nscalaTime = "com.github.nscala-time" %% "nscala-time" % "2.4.0"
 val gson = "com.google.code.gson" % "gson" % "2.2.3"
-val goPluginLibrary = "cd.go.plugin" % "go-plugin-api" % "17.2.0" % Provided
+val goPluginLibrary = "cd.go.plugin" % "go-plugin-api" % "23.4.0"
 val jaxbApi = "javax.xml.bind" % "jaxb-api" % "2.3.0"
+val servlet = "javax.servlet" % "javax.servlet-api" % "3.1.0" 
 
 val hamcrest = "org.hamcrest" % "hamcrest-all" % "1.3" % Test
 val junit = "junit" % "junit" % "4.12" % Test
@@ -14,6 +15,7 @@ val mockito = "org.mockito" % "mockito-all" % "1.10.19" % Test
 val scalaTest = "org.scalatest" %% "scalatest" % "2.2.0" % Test
 
 val appVersion = sys.env.get("TRAVIS_TAG") orElse sys.env.get("BUILD_LABEL") getOrElse s"1.0.0-${System.currentTimeMillis / 1000}-SNAPSHOT"
+
 
 lazy val root = Project(
   id = "gocd-s3-artifacts",
@@ -26,7 +28,7 @@ lazy val commonSettings = Seq(
   scalaVersion := "2.11.12",
   unmanagedBase := file(".") / "lib",
   libraryDependencies ++= Seq(
-    apacheCommons, commonsIo, awsS3, goPluginLibrary, gson, jaxbApi
+    apacheCommons, commonsIo, awsS3, goPluginLibrary, gson, servlet, jaxbApi
   ),
   resourceGenerators in Compile += Def.task {
     val inputFile = baseDirectory.value / "template" / "plugin.xml"

--- a/utils/src/test/java/com/indix/gocd/utils/mocks/MockContext.java
+++ b/utils/src/test/java/com/indix/gocd/utils/mocks/MockContext.java
@@ -1,9 +1,6 @@
 package com.indix.gocd.utils.mocks;
 
 import com.indix.gocd.utils.Context;
-import com.thoughtworks.go.plugin.api.task.Console;
-import com.thoughtworks.go.plugin.api.task.EnvironmentVariables;
-import com.thoughtworks.go.plugin.api.task.TaskExecutionContext;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.InputStream;


### PR DESCRIPTION
These plugins do not load on newer versions of agents,  definitely not on v23.4.0,  but possibly earlier versions too.  This is due to the significant changes in the GoCD plugin API libraries

This patch fixes the issue. 